### PR TITLE
Add missing header stddef.h to fix builds on Linux

### DIFF
--- a/src/qmc_crypto.h
+++ b/src/qmc_crypto.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 uint8_t qmc_crypto_encode(unsigned int i);
 void qmc_crypto_transform(uint8_t* data, unsigned int offset, size_t size);


### PR DESCRIPTION
size_t is defined in stddef.h

this pull request fixup buils error on Linux

```
In file included from qmc_crypto.c:1:
qmc_crypto.h:6:63: error: unknown type name ‘size_t’
 void qmc_crypto_transform(uint8_t* data, unsigned int offset, size_t size);
                                                               ^~~~~~
qmc_crypto.h:6:63: note: ‘size_t’ is defined in header ‘<stddef.h>’; did you forget to ‘#include <stddef.h>’?
qmc_crypto.h:4:1:
+#include <stddef.h>
```